### PR TITLE
For focus-android#5608: add focus support to backfill.py

### DIFF
--- a/backfill.py
+++ b/backfill.py
@@ -11,6 +11,7 @@ import sys
 import measure_start_up
 import time
 from pathlib import Path
+from measure_start_up import PROD_TO_CHANNEL_TO_PKGID, PROD_FENIX
 from datetime import datetime, timedelta
 
 DESCRIPTION = """ Allows to get startup performance metrics between two dates.
@@ -35,13 +36,6 @@ KEY_ARCHITECTURE = "architecture"
 KEY_TEST_NAME = "test_name"
 
 DATETIME_FORMAT = "%Y.%m.%d"
-
-FENIX_CHANNEL_TO_PKG = {
-    'nightly': 'org.mozilla.fenix',
-    'beta': 'org.mozilla.firefox.beta',
-    'release': 'org.mozilla.firefox',
-    'debug': 'org.mozilla.fenix.debug'
-}
 
 MEASURE_START_UP_SCRIPT = "./measure_start_up.py"
 
@@ -313,7 +307,7 @@ def main():
             remote_name=args.git_remote_name if args.git_remote_name else "")
 
     run_performance_analysis_on_nightly(
-        FENIX_CHANNEL_TO_PKG[args.release_channel],
+        PROD_TO_CHANNEL_TO_PKGID[PROD_FENIX][args.release_channel],
         MEASURE_START_UP_SCRIPT,
         array_of_apk_metadata,
         args.release_channel,

--- a/backfill_upload.py
+++ b/backfill_upload.py
@@ -89,7 +89,7 @@ def upload(perf_result, auth_token, is_dry_run):
     req_data = '{metric},device={device},product={product} value={value} {timestamp}'.format(
         metric=metric_name,
         device="moto-g5",
-        product="fenix-nightly",
+        product=perf_result[backfill.KEY_PRODUCT] + '-nightly',  # we only support nightly currently
         value=perf_result[KEY_MEDIAN],
         timestamp=perf_result[KEY_TIMESTAMP_EPOCH],
     )

--- a/measure_start_up.py
+++ b/measure_start_up.py
@@ -35,7 +35,7 @@ PROD_TO_CHANNEL_TO_PKGID[PROD_FENIX] = {
     'debug': 'org.mozilla.fenix.debug'
 }
 PROD_TO_CHANNEL_TO_PKGID[PROD_FOCUS] = {
-    'nightly': 'org.mozilla.focus',  # it seems problematic that this is the same as release.
+    'nightly': 'org.mozilla.focus.nightly',
     'beta': 'org.mozilla.focus.beta',  # only present since post-fenix update.
     'release': 'org.mozilla.focus',
     'debug': 'org.mozilla.focus.debug'


### PR DESCRIPTION
For https://github.com/mozilla-mobile/focus-android/issues/5608.

You can see sample results from 09/29 (the first day of nightlies) and 10/11 at [the new dashboard](https://earthangel-b40313e5.influxcloud.net/d/7u0o-gdnz/focus-startup-nightly-via-backfill-py?orgId=1&from=now-30d&to=now).